### PR TITLE
chore(release): amélioration du bundle et gestion des versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           # S'assurer que les images pointent vers les bonnes versions
           sed -i "s/synergia-frontend:latest/synergia-frontend:$VERSION/g" release/docker-compose.yaml
           sed -i "s/synergia-backend:latest/synergia-backend:$VERSION/g" release/docker-compose.yaml
-          cp .env.prod release/.env.example
+          cp .env.prod release/.env
 
           # Nettoyer .env.example - remplacer les vraies valeurs par CHANGEME
           sed -i 's/MYSQL_ROOT_PASSWORD=.*/MYSQL_ROOT_PASSWORD=CHANGEME_STRONG_PASSWORD/' release/.env.example
@@ -92,7 +92,7 @@ jobs:
           cp validate-bundle.sh release/
 
           # Copier le Caddyfile
-          cp Caddyfile.prod release/Caddyfile
+          cp Caddyfile.prod release/Caddyfile.prod
 
           # S'assurer que les scripts sont exécutables
           chmod +x release/deploy.sh release/rollback.sh release/validate-bundle.sh

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "private": true,
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "server.js",
   "scripts": {
     "test": "cross-env NODE_ENV=test jest --forceExit --detectOpenHandles",


### PR DESCRIPTION
- Correction du workflow pour copier .env.prod en .env et .env.example dans le bundle
- Correction de la copie du Caddyfile sous le nom Caddyfile.prod
- Mise à jour des versions dans client/package.json et server/package.json
- Le bundle utilise la version de client/package.json pour nommer les images et l’archive de release