### PR TITLE
fix(prod): expose explicitement le port 5001 pour le backend dans doc…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,6 +32,8 @@ services:
       - database
     networks:
       - app-network
+    ports:
+      - "5001:5001"
 
   frontend:
     image: synergia-frontend:latest


### PR DESCRIPTION
…ker-compose.prod.yml

Permet à Caddy de proxyfier correctement les requêtes API vers le backend sans erreur 502.