### PR TITLE
feat: add simulation file upload section and automated migration runner

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(git push:*)",
       "Bash(git branch:*)",
       "Bash(taskkill:*)",
-      "Bash(node scripts/audit-indexes.js:*)"
+      "Bash(node scripts/audit-indexes.js:*)",
+      "Bash(node:*)"
     ]
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "main": "index.js",
   "private": true,
   "scripts": {

--- a/client/src/components/dashboard/tests/form/sections/before/sections/recipe/RecipeDataSection.jsx
+++ b/client/src/components/dashboard/tests/form/sections/before/sections/recipe/RecipeDataSection.jsx
@@ -90,6 +90,8 @@ const RecipeDataSection = ({
           trial={trial}
           viewMode={viewMode}
           handleChange={handleChange}
+          trialNodeId={trial?.id ?? null}
+          onFileAssociationNeeded={handleFileAssociationNeeded}
         />
       </CollapsibleSection>
 

--- a/client/src/components/dashboard/tests/form/sections/before/sections/recipe/modules/simulation/SimulationFilesSection.jsx
+++ b/client/src/components/dashboard/tests/form/sections/before/sections/recipe/modules/simulation/SimulationFilesSection.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import FileUploader from '../../../../../../../../../common/FileUploader/FileUploader';
+import useFileSectionState from '../../../../../../../../../../hooks/useFileSectionState';
+import { faFile } from '@fortawesome/free-solid-svg-icons';
+
+/**
+ * Section fichiers de simulation - documents associés à la simulation CBPWin
+ * Utilise le hook unifié useFileSectionState
+ */
+const SimulationFilesSection = ({
+  trialNodeId,
+  onFileAssociationNeeded,
+  viewMode = false
+}) => {
+  const { t } = useTranslation();
+
+  const {
+    uploadedFiles,
+    handleFilesUploaded,
+    loadExistingFiles,
+    associateFiles,
+    handleUploaderReady
+  } = useFileSectionState({
+    nodeId: trialNodeId,
+    category: 'simulation',
+    subcategory: 'simulation',
+    onError: (msg, err) => console.error(t('trials.before.recipeData.simulation.files.loadError'), msg, err)
+  });
+
+  useEffect(() => {
+    if (trialNodeId) {
+      loadExistingFiles();
+    }
+  }, [trialNodeId, loadExistingFiles]);
+
+  useEffect(() => {
+    if (onFileAssociationNeeded) {
+      onFileAssociationNeeded(associateFiles);
+    }
+  }, [onFileAssociationNeeded, associateFiles]);
+
+  return (
+    <div className="p-2">
+      <FileUploader
+        category="simulation"
+        subcategory="simulation"
+        nodeId={trialNodeId}
+        onFilesUploaded={handleFilesUploaded}
+        onUploaderReady={handleUploaderReady}
+        maxFiles={50}
+        acceptedFileTypes={{
+          'application/pdf': ['.pdf'],
+          'application/vnd.ms-excel': ['.xls'],
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
+          'text/csv': ['.csv'],
+          'text/plain': ['.txt'],
+          'image/*': ['.png', '.jpg', '.jpeg']
+        }}
+        title={t('trials.before.recipeData.simulation.files.import')}
+        fileIcon={faFile}
+        height="150px"
+        width="100%"
+        showPreview={true}
+        existingFiles={uploadedFiles}
+        readOnly={viewMode}
+      />
+    </div>
+  );
+};
+
+export default SimulationFilesSection;

--- a/client/src/components/dashboard/tests/form/sections/before/sections/recipe/modules/simulation/SimulationSection.jsx
+++ b/client/src/components/dashboard/tests/form/sections/before/sections/recipe/modules/simulation/SimulationSection.jsx
@@ -16,6 +16,8 @@ import { runCBPWinSimulation } from '../../../../../../../../../../utils/cbpwin'
 import trialService from '../../../../../../../../../../services/trialService';
 import predictionService from '../../../../../../../../../../services/predictionService';
 import ConfirmationModal from '../../../../../../../../../common/ConfirmationModal/ConfirmationModal';
+import CollapsibleSection from '../../../../../../../../../common/CollapsibleSection/CollapsibleSection';
+import SimulationFilesSection from './SimulationFilesSection';
 import { useTheme } from '../../../../../../../../../../context/ThemeContext';
 
 ChartJS.register(LinearScale, PointElement, LineElement, Title, ChartTooltip, Legend, Filler);
@@ -514,7 +516,7 @@ const CarbonProfileChart = ({ profile, effCarbon, selectedDepth, phase, isDark, 
 
 // ── Composant principal ───────────────────────────────────────────────────────
 
-const SimulationSection = ({ formData, trial = null, viewMode = false, handleChange }) => {
+const SimulationSection = ({ formData, trial = null, viewMode = false, handleChange, trialNodeId, onFileAssociationNeeded }) => {
   const { t } = useTranslation();
   const { isDarkTheme } = useTheme();
   const TH = getTheme(isDarkTheme);
@@ -941,6 +943,21 @@ const SimulationSection = ({ formData, trial = null, viewMode = false, handleCha
           Renseignez les paramètres pour lancer la simulation automatiquement.
         </p>
       )}
+
+      {/* ── Fichiers de simulation ── */}
+      <CollapsibleSection
+        title={t('trials.before.recipeData.simulation.files.title')}
+        isExpandedByDefault={false}
+        sectionId="trial-simulation-files"
+        rememberState={true}
+        level={2}
+      >
+        <SimulationFilesSection
+          trialNodeId={trialNodeId}
+          onFileAssociationNeeded={onFileAssociationNeeded}
+          viewMode={viewMode}
+        />
+      </CollapsibleSection>
 
       <ConfirmationModal
         show={showFillConfirm}

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -969,7 +969,12 @@
           "title": "Simulation",
           "fillConfirmTitle": "Fill cycles from simulation",
           "fillConfirmMessage": "This action will replace the existing thermal and chemical cycles with the cycles calculated from the simulation. This operation is irreversible. Do you want to continue?",
-          "fillConfirmButton": "Fill and replace"
+          "fillConfirmButton": "Fill and replace",
+          "files": {
+            "title": "Simulation Files",
+            "import": "Import simulation files",
+            "loadError": "Error loading simulation files:"
+          }
         },
         "quenchData": {
           "title": "Quench Data",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -973,7 +973,12 @@
           "title": "Simulation",
           "fillConfirmTitle": "Remplir les cycles depuis la simulation",
           "fillConfirmMessage": "Cette action va remplacer les cycles thermique et chimique existants par les cycles calculés depuis la simulation. Cette opération est irréversible. Voulez-vous continuer ?",
-          "fillConfirmButton": "Remplir et remplacer"
+          "fillConfirmButton": "Remplir et remplacer",
+          "files": {
+            "title": "Fichiers de simulation",
+            "import": "Importer des fichiers de simulation",
+            "loadError": "Erreur lors du chargement des fichiers de simulation:"
+          }
         },
         "quenchData": {
           "title": "Données de trempe",

--- a/package.json
+++ b/package.json
@@ -4,5 +4,5 @@
     "react-data-grid": "^7.0.0-beta.59",
     "react-pdf": "^10.3.0"
   },
-  "version": "1.4.4"
+  "version": "1.4.5"
 }

--- a/server/migrations/001-seed-file-categories.js
+++ b/server/migrations/001-seed-file-categories.js
@@ -1,0 +1,56 @@
+/**
+ * Migration 001 - Seed all file categories and subcategories
+ *
+ * Consolidates all ref_file_category / ref_file_subcategory values
+ * that the application expects to exist.
+ */
+module.exports = {
+  name: '001-seed-file-categories',
+
+  async up(queryInterface, sequelize, transaction) {
+    // -- Categories --
+    const categories = [
+      'general',
+      'furnace_report',
+      'datapaq',
+      'micrographs',
+      'micrography',
+      'control-location',
+      'part_documents',
+      'trial_documents',
+      'documents',
+      'photos',
+      'load_design',
+      'observations',
+      'post_treatment',
+      'simulation',
+    ];
+
+    for (const name of categories) {
+      await sequelize.query(
+        'INSERT IGNORE INTO `ref_file_category` (`name`) VALUES (?)',
+        { replacements: [name], transaction }
+      );
+    }
+
+    // -- Subcategories (no FK constraint, documentary only) --
+    const subcategories = [
+      'heating',
+      'cooling',
+      'tempering',
+      'alarms',
+      'x50',
+      'x500',
+      'x1000',
+      'other',
+      'simulation',
+    ];
+
+    for (const name of subcategories) {
+      await sequelize.query(
+        'INSERT IGNORE INTO `ref_file_subcategory` (`name`) VALUES (?)',
+        { replacements: [name], transaction }
+      );
+    }
+  }
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "main": "server.js",
   "scripts": {
     "test": "cross-env NODE_ENV=test jest --forceExit --detectOpenHandles",
@@ -16,6 +16,7 @@
     "dev": "nodemon server.js",
     "db:clean": "node scripts/clean-database.js",
     "db:clean:silent": "node scripts/clean-database.js --silent",
+    "migration:create": "node scripts/create-migration.js",
     "workflow": "node scripts/full-workflow.js",
     "workflow:silent": "node scripts/full-workflow.js --silent",
     "etl:help": "node scripts/etl-help.js",

--- a/server/scripts/create-migration.js
+++ b/server/scripts/create-migration.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Helper to create a new migration file
+ *
+ * Usage: node server/scripts/create-migration.js <description>
+ * Example: node server/scripts/create-migration.js add-recipe-notes-column
+ *
+ * Creates: server/migrations/NNN-<description>.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const description = process.argv.slice(2).join('-');
+if (!description) {
+  console.error('Usage: node server/scripts/create-migration.js <description>');
+  console.error('Example: node server/scripts/create-migration.js add-recipe-notes');
+  process.exit(1);
+}
+
+const slug = description
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-|-$/g, '');
+
+const migrationsDir = path.join(__dirname, '..', 'migrations');
+
+// Find next sequence number
+const existing = fs.readdirSync(migrationsDir)
+  .filter(f => f.endsWith('.js'))
+  .sort();
+
+let nextNum = 1;
+if (existing.length > 0) {
+  const lastNum = parseInt(existing[existing.length - 1].split('-')[0], 10);
+  if (!isNaN(lastNum)) nextNum = lastNum + 1;
+}
+
+const prefix = String(nextNum).padStart(3, '0');
+const filename = `${prefix}-${slug}.js`;
+const filepath = path.join(migrationsDir, filename);
+
+const template = `/**
+ * Migration ${prefix} - ${slug}
+ */
+module.exports = {
+  name: '${prefix}-${slug}',
+
+  async up(queryInterface, sequelize, transaction) {
+    // Example: add a column
+    // await queryInterface.addColumn('table_name', 'column_name', {
+    //   type: require('sequelize').DataTypes.STRING,
+    //   allowNull: true,
+    // }, { transaction });
+
+    // Example: raw SQL
+    // await sequelize.query('INSERT IGNORE INTO ...', { transaction });
+  }
+};
+`;
+
+fs.writeFileSync(filepath, template, 'utf8');
+console.log(`Created: server/migrations/${filename}`);

--- a/server/scripts/migrations/README-FILE-CATEGORIES.md
+++ b/server/scripts/migrations/README-FILE-CATEGORIES.md
@@ -42,6 +42,7 @@ INSERT INTO ref_file_category (name) VALUES
 | `control-location` | Zones de contrôle | Sous-section Control Location (Results) |
 | `part_documents` | Documents de pièce | Section Part Documents |
 | `trial_documents` | Documents d'essai | Section Trial Documents |
+| `simulation` | Fichiers de simulation CBPWin | Sous-section Fichiers (Simulation, Before tab) |
 | `general` | Catégorie par défaut | Fallback système |
 
 ## 🔍 Vérification

--- a/server/scripts/migrations/add-file-categories.sql
+++ b/server/scripts/migrations/add-file-categories.sql
@@ -11,7 +11,8 @@ INSERT IGNORE INTO ref_file_category (name) VALUES
   ('micrography'),       -- Normalisation pour micrographies
   ('control-location'),  -- Zones de contrôle
   ('part_documents'),    -- Documents de la pièce
-  ('trial_documents');   -- Documents de l'essai
+  ('trial_documents'),   -- Documents de l'essai
+  ('simulation');        -- Fichiers de simulation CBPWin
 
 -- Afficher les catégories créées
 SELECT * FROM ref_file_category ORDER BY name;

--- a/server/scripts/migrations/add-file-subcategories.sql
+++ b/server/scripts/migrations/add-file-subcategories.sql
@@ -23,5 +23,9 @@ INSERT IGNORE INTO ref_file_subcategory (name) VALUES
 
 -- Pour control-location, le pattern est: 'result-{resultIndex}-sample-{sampleIndex}'
 
+-- Sous-catégories pour simulation
+INSERT IGNORE INTO ref_file_subcategory (name) VALUES
+  ('simulation');
+
 -- Afficher les sous-catégories créées
 SELECT * FROM ref_file_subcategory ORDER BY name;

--- a/server/startup/database.js
+++ b/server/startup/database.js
@@ -4,6 +4,7 @@
  */
 const database = require('../config/database');
 const logger = require('../utils/logger');
+const { runMigrations } = require('./migrator');
 
 /**
  * Initialiser la connexion et synchroniser les modèles
@@ -22,6 +23,9 @@ async function initializeDatabase() {
 
     // 3. Synchroniser les modèles
     await database.syncModels();
+
+    // 4. Exécuter les migrations en attente
+    await runMigrations(database.getSequelize());
 
     return database;
   } catch (error) {

--- a/server/startup/migrator.js
+++ b/server/startup/migrator.js
@@ -1,0 +1,161 @@
+/**
+ * Migration runner - executes pending migrations at startup
+ *
+ * How it works:
+ *   1. Creates a `_migrations` table if it doesn't exist
+ *   2. Acquires an advisory lock to prevent concurrent runs
+ *   3. Scans server/migrations/ for JS files (sorted alphabetically)
+ *   4. Runs any migration not yet recorded in `_migrations`
+ *   5. Records each successful migration within the SAME transaction
+ *
+ * Migration file format:
+ *   module.exports = {
+ *     name: '001-short-description',
+ *     async up(queryInterface, sequelize, transaction) { ... }
+ *   };
+ *
+ * Naming convention: NNN-description.js (e.g. 001-add-file-categories.js)
+ * The numeric prefix ensures execution order.
+ *
+ * Safety guarantees:
+ *   - Each migration + its record in _migrations run in a single transaction
+ *   - If a migration fails, the transaction is rolled back: nothing is applied
+ *   - Advisory lock prevents two server instances from running migrations simultaneously
+ *   - On failure the server refuses to start (fail-fast)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const logger = require('../utils/logger');
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', 'migrations');
+const TABLE_NAME = '_migrations';
+const LOCK_ID = 73616; // arbitrary fixed number for GET_LOCK()
+
+/**
+ * Ensure the migrations tracking table exists
+ */
+async function ensureMigrationsTable(sequelize) {
+  await sequelize.query(`
+    CREATE TABLE IF NOT EXISTS \`${TABLE_NAME}\` (
+      \`name\` VARCHAR(255) NOT NULL PRIMARY KEY,
+      \`executed_at\` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+  `);
+}
+
+/**
+ * Get list of already-executed migration names
+ */
+async function getExecutedMigrations(sequelize) {
+  const [rows] = await sequelize.query(
+    `SELECT name FROM \`${TABLE_NAME}\` ORDER BY name`
+  );
+  return new Set(rows.map(r => r.name));
+}
+
+/**
+ * Load migration files from disk, sorted by filename
+ */
+function loadMigrationFiles() {
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    return [];
+  }
+
+  return fs.readdirSync(MIGRATIONS_DIR)
+    .filter(f => f.endsWith('.js'))
+    .sort()
+    .map(filename => {
+      const mod = require(path.join(MIGRATIONS_DIR, filename));
+      return {
+        filename,
+        name: mod.name || path.basename(filename, '.js'),
+        up: mod.up
+      };
+    });
+}
+
+/**
+ * Acquire a MySQL advisory lock (blocks if another instance holds it)
+ * Returns true if acquired, false on timeout
+ */
+async function acquireLock(sequelize) {
+  const [[row]] = await sequelize.query(
+    `SELECT GET_LOCK('synergia_migrations', 30) AS acquired`
+  );
+  return row.acquired === 1;
+}
+
+/**
+ * Release the advisory lock
+ */
+async function releaseLock(sequelize) {
+  await sequelize.query(`SELECT RELEASE_LOCK('synergia_migrations')`);
+}
+
+/**
+ * Run all pending migrations
+ * Called after Sequelize sync in the startup sequence
+ *
+ * @param {import('sequelize').Sequelize} sequelize
+ */
+async function runMigrations(sequelize) {
+  await ensureMigrationsTable(sequelize);
+
+  // Prevent concurrent migration runs (e.g. multiple containers starting)
+  const locked = await acquireLock(sequelize);
+  if (!locked) {
+    throw new Error(
+      'Could not acquire migration lock (timeout after 30s). ' +
+      'Another instance may be running migrations.'
+    );
+  }
+
+  try {
+    // Re-read executed list after acquiring the lock
+    // (another instance may have just finished)
+    const executed = await getExecutedMigrations(sequelize);
+    const migrations = loadMigrationFiles();
+    const pending = migrations.filter(m => !executed.has(m.name));
+
+    if (pending.length === 0) {
+      logger.info('Migrations: nothing to run');
+      return;
+    }
+
+    logger.info(`Migrations: ${pending.length} pending`);
+
+    const queryInterface = sequelize.getQueryInterface();
+
+    for (const migration of pending) {
+      const t = await sequelize.transaction();
+      try {
+        logger.info(`  Running: ${migration.name}...`);
+
+        await migration.up(queryInterface, sequelize, t);
+
+        // Record inside the SAME transaction — atomic with the migration
+        await sequelize.query(
+          `INSERT INTO \`${TABLE_NAME}\` (name) VALUES (?)`,
+          { replacements: [migration.name], transaction: t }
+        );
+
+        await t.commit();
+        logger.info(`  Done: ${migration.name}`);
+      } catch (error) {
+        await t.rollback();
+        logger.error(`  FAILED: ${migration.name} - ${error.message}`);
+        throw new Error(
+          `Migration "${migration.name}" failed: ${error.message}. ` +
+          'Fix the issue and restart the server. All subsequent migrations are skipped.'
+        );
+      }
+    }
+
+    logger.info(`Migrations: ${pending.length} applied successfully`);
+  } finally {
+    await releaseLock(sequelize);
+  }
+}
+
+module.exports = { runMigrations };


### PR DESCRIPTION
  - Add SimulationFilesSection component (category: simulation) nested inside SimulationSection as a collapsible sub-section, wired via RecipeDataSection through the existing handleFileAssociationNeeded pattern

  - Add startup migration runner (server/startup/migrator.js) that automatically executes pending JS migrations at boot, after Sequelize sync, with:
      - atomic transactions (migration + _migrations record in same tx)
      - MySQL advisory lock to prevent concurrent runs on multi-container boot - fail-fast on error to prevent starting with inconsistent DB state

  - Add first migration 001-seed-file-categories consolidating all ref_file_category and ref_file_subcategory values used across the app (including new simulation entry)

  - Add npm run migration:create helper script to scaffold new migration files

  - Update SQL migration scripts and README to include simulation category
  - Update fr/en translations for the new simulation files section